### PR TITLE
[ACS-1885] libraries version bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-super-pom</artifactId>
-        <version>9</version>
+        <version>12</version>
     </parent>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     </distributionManagement>
 
     <properties>
-        <dependency.alfresco-repository.version>6.0</dependency.alfresco-repository.version>
+        <dependency.alfresco-repository.version>11.109</dependency.alfresco-repository.version>
         <dependency.truezip.version>7.7.9</dependency.truezip.version>
     </properties>
 


### PR DESCRIPTION
Bumped versions of libraries to prevent security vulnerabilities:
* alfresco-repository version bumped to 11.109 which contains proper version of commons-compress library (1.21)